### PR TITLE
Keep iterating even when null values are found. Then choose the last one

### DIFF
--- a/coned/meter.py
+++ b/coned/meter.py
@@ -97,9 +97,8 @@ class Meter(object):
             jsonResponse = json.loads(self.raw_data)
             lastRead = None
             for read in jsonResponse['reads']:
-                if read['value'] is None:
-                    break
-                lastRead = read
+                if read['value'] is not None:
+                    lastRead = read
             _LOGGER.debug("lastRead = %s", lastRead)
 
             self.startTime = lastRead['startTime']


### PR DESCRIPTION
I received data from oru.com at around 11:15 PM yesterday, which looked like below. 

<pre>
  <code>
  {
      "startTime": "2021-08-24T22:45:00-04:00",
      "endTime": "2021-08-24T23:00:00-04:00",
      "value": 0.572
  },
  {
      "startTime": "2021-08-24T23:00:00-04:00",
      "endTime": "2021-08-24T23:15:00-04:00",
      "value": 0.718
  },
  {
      <strong>"startTime": "2021-08-24T23:15:00-04:00",</strong>
      <strong>"endTime": "2021-08-24T23:30:00-04:00",</strong>
      <strong>"value": null</strong>
  },
  {
      "startTime": "2021-08-24T23:30:00-04:00",
      "endTime": "2021-08-24T23:45:00-04:00",
      "value": 0.225
  },
  {
      "startTime": "2021-08-24T23:45:00-04:00",
      "endTime": "2021-08-25T00:00:00-04:00",
      "value": 0.245
  },
  </code>
</pre>


This caused my feed to stop around that time last night. Hence this fix