### PR TITLE
add all_reads method

### DIFF
--- a/coned/meter.py
+++ b/coned/meter.py
@@ -105,7 +105,6 @@ class Meter(object):
             if 'error' in jsonResponse:
                 self._LOGGER.info("got JSON error back = %s", jsonResponse['error']['details'])
                 raise MeterError(jsonResponse['error']['details'])
-            self._LOGGER.info("got JSON response containing reads")
             for read in jsonResponse['reads']:
                 if read['value'] is not None:
                     availableReads.append(read)
@@ -222,7 +221,7 @@ class Meter(object):
         # # api_page = await browser.newPage()
         # api_url = 'https://' + self.data_site + '.opower.com/ei/edge/apis/cws-real-time-ami-v1/cws/' + self.data_site + '/accounts/' + self.account_uuid + '/meters/' + self.meter_number + '/usage'
         # await page.goto(api_url)
-        await page.screenshot({'path': 'meter4-1.png'})
+        # await page.screenshot({'path': 'meter4-1.png'})
         self._LOGGER.debug('meter4-1')
 
         self._LOGGER.debug(f"raw_data = {raw_data}")

--- a/coned/meter.py
+++ b/coned/meter.py
@@ -38,8 +38,6 @@ class Meter(object):
     def __init__(self, email, password, mfa_type, mfa_secret, account_uuid, meter_number, account_number=None, site='coned', loop=None, browser_path=None):
         self._LOGGER = logging.getLogger(__name__)
 
-        logging.basicConfig(level=logging.INFO)
-
         """Return a meter object whose meter id is *meter_number*"""
         self.email = email
         if self.email is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 pyppeteer
+pyotp


### PR DESCRIPTION
[For my usecase](https://github.com/NickBorgers/coned-data-visualizer) I needed to get accurate historic data, and the "last read" doesn't give me a complete picture because ConEd's data pipeline has fits and starts. Now I pull all available data and inject it, possibly overwriting existing records but that's OK.

I couldn't run your unit tests, but this code does work as called from here: https://github.com/NickBorgers/coned-data-visualizer/blob/main/coned-collector/script.py#L59